### PR TITLE
feat: add smart contract

### DIFF
--- a/contracts/contracts/Certificates.sol
+++ b/contracts/contracts/Certificates.sol
@@ -2,18 +2,120 @@
 pragma solidity ^0.8.28;
 
 contract Certificates {
-  uint public x;
+    struct Certificate {
+        string serialNumber;
+        string ipfsCID;
+        bytes32 certificateHash;
+        address owner;
+        uint256 timestamp;
+        bool revoked;
+    }
 
-  event Increment(uint by);
+    // certificates maps a serial number to a specific certificate
+    mapping(string => Certificate) public certificates;
 
-  function inc() public {
-    x++;
-    emit Increment(1);
-  }
+    // ownerCertificates maps an owner's address to their certificate's serial numbers
+    mapping(address => string[]) public ownerCertificates;
 
-  function incBy(uint by) public {
-    require(by > 0, "incBy: increment should be positive");
-    x += by;
-    emit Increment(by);
-  }
+    // allSerial numbers represents a list of all expired, valid, and revoked certificate serial numbers.
+    string[] public allSerialNumbers;
+
+    // CertificateRegistered is thrown when a certificate is added to the chain
+    event CertificateRegistered(
+        string indexed serialNumber,
+        string ipfsCID,
+        bytes32 certificateHash,
+        address indexed owner,
+        uint256 timestamp
+    );
+
+    // CertificateRevoked is thrown when a certificate is revoked
+    event CertificateRevoked(
+        string indexed serialNumber,
+        address indexed revokedBy,
+        uint256 timestamp
+    );
+
+    //registerCertificate is used for adding a new certificate to the chain of trust
+    function registerCertificate(
+        string memory serialNumber,
+        string memory ipfsCID,
+        bytes32 certificateHash
+    ) public {
+        require(bytes(serialNumber).length > 0, "Serial number cannot be empty");
+        require(bytes(ipfsCID).length > 0, "IPFS CID cannot be empty");
+        require(certificateHash != bytes32(0), "Certificate hash cannot be empty");
+        require(bytes(certificates[serialNumber].serialNumber).length == 0, "Certificate already registered");
+
+        Certificate memory cert = Certificate({
+            serialNumber: serialNumber,
+            ipfsCID: ipfsCID,
+            certificateHash: certificateHash,
+            owner: msg.sender,
+            timestamp: block.timestamp,
+            revoked: false
+        });
+
+        certificates[serialNumber] = cert;
+        ownerCertificates[msg.sender].push(serialNumber);
+        allSerialNumbers.push(serialNumber);
+
+        emit CertificateRegistered(
+            serialNumber,
+            ipfsCID,
+            certificateHash,
+            msg.sender,
+            block.timestamp
+        );
+    }
+
+    //revokeCertificate allows the owner of a certificate to mark it as no longer trusted
+    function revokeCertificate(string memory serialNumber) public {
+        Certificate storage cert = certificates[serialNumber];
+        require(bytes(cert.serialNumber).length > 0, "Certificate does not exist");
+        require(cert.owner == msg.sender, "Only the certificate owner can revoke it");
+        require(!cert.revoked, "Certificate already revoked");
+
+        cert.revoked = true;
+
+        emit CertificateRevoked(serialNumber, msg.sender, block.timestamp);
+    }
+
+    // getCertificate allows retrieval of a certificate by its serial number
+    function getCertificate(string memory serialNumber) public view returns (
+        string memory,
+        string memory,
+        bytes32,
+        address,
+        uint256,
+        bool
+    ) {
+        Certificate memory cert = certificates[serialNumber];
+        require(bytes(cert.serialNumber).length > 0, "Certificate does not exist");
+
+        return (
+            cert.serialNumber,
+            cert.ipfsCID,
+            cert.certificateHash,
+            cert.owner,
+            cert.timestamp,
+            cert.revoked
+        );
+    }
+
+    // isValid is the main way to validate that a certificate is still valid and not revoked
+    function isValid(string memory serialNumber, bytes32 certificateHash) public view returns (bool) {
+        Certificate memory cert = certificates[serialNumber];
+        return bytes(cert.serialNumber).length > 0 && !cert.revoked && cert.certificateHash == certificateHash;
+    }
+
+    // getOwnerCertificates returns a list of all certificate associated with a specific owner address
+    function getOwnerCertificates(address owner) public view returns (string[] memory) {
+        return ownerCertificates[owner];
+    }
+
+    // getTotalCertificates return the total number of certificates on the chain, revoked and valid.
+    function getTotalCertificates() public view returns (uint256) {
+        return allSerialNumbers.length;
+    }
 }

--- a/contracts/contracts/Certificates.t.sol
+++ b/contracts/contracts/Certificates.t.sol
@@ -8,25 +8,120 @@ import {Test} from "forge-std/Test.sol";
 // use the same syntax and offer the same functionality.
 
 contract CertificatesTest is Test {
-  Certificates counter;
+  Certificates certificates;
 
-  function setUp() public {
-    counter = new Certificates();
-  }
-
-  function test_InitialValue() public view {
-    require(counter.x() == 0, "Initial value should be 0");
-  }
-
-  function testFuzz_Inc(uint8 x) public {
-    for (uint8 i = 0; i < x; i++) {
-      counter.inc();
+    function setUp() public {
+        certificates = new Certificates();
     }
-    require(counter.x() == x, "Value after calling inc x times should be x");
-  }
 
-  function test_IncByZero() public {
-    vm.expectRevert();
-    counter.incBy(0);
-  }
+    function test_InitialCertNumber() public view {
+        require(certificates.getTotalCertificates() == 0, "Initial number of certs should be 0");
+    }
+
+    function CertificateRegistersSuccessfully() public {
+        string memory serialNumber = "abc1234";
+        string memory ipfsCID = "fake-ipfs-cid";
+        bytes32 certificateHash = keccak256("test-cert-hash");
+
+        certificates.registerCertificate(serialNumber, ipfsCID, certificateHash);
+
+        require(certificates.getTotalCertificates() == 1, "Should have 1 certificate");
+
+        (
+            string memory retSerial,
+            string memory retIpfs,
+            bytes32 retHash,
+            address retOwner,
+            uint256 retTimestamp,
+            bool retRevoked
+        ) = certificates.getCertificate(serialNumber);
+
+        require(keccak256(bytes(retSerial)) == keccak256(bytes(serialNumber)), "Serial number mismatch");
+        require(keccak256(bytes(retIpfs)) == keccak256(bytes(ipfsCID)), "IPFS CID mismatch");
+        require(retHash == certificateHash, "Certificate hash mismatch");
+        require(retOwner == address(this), "Owner mismatch");
+        require(!retRevoked, "Certificate should not be revoked");
+        require(retTimestamp > 0, "Timestamp should be set");
+    }
+
+    function test_RevertOnEmptySerialNumber() public {
+        vm.expectRevert("Serial number cannot be empty");
+        certificates.registerCertificate("", "QmHash", keccak256("hash"));
+    }
+
+    function test_RevertOnEmptyIPFS() public {
+        vm.expectRevert("IPFS CID cannot be empty");
+        certificates.registerCertificate("cert001", "", keccak256("hash"));
+    }
+
+    function test_RevertOnEmptyHash() public {
+        vm.expectRevert("Certificate hash cannot be empty");
+        certificates.registerCertificate("cert001", "QmHash", bytes32(0));
+    }
+
+    function test_RevertOnDuplicateRegistration() public {
+        string memory serial = "cert001";
+        certificates.registerCertificate(serial, "QmHash", keccak256("hash"));
+
+        vm.expectRevert("Certificate already registered");
+        certificates.registerCertificate(serial, "QmHash2", keccak256("hash2"));
+    }
+
+    function testFuzz_RegisterCertificate(
+        string memory serialNumber,
+        string memory ipfsCID,
+        bytes32 certificateHash
+    ) public {
+        vm.assume(bytes(serialNumber).length > 0);
+        vm.assume(bytes(ipfsCID).length > 0);
+        vm.assume(certificateHash != bytes32(0));
+
+        certificates.registerCertificate(serialNumber, ipfsCID, certificateHash);
+
+        require(certificates.getTotalCertificates() == 1, "Should have 1 certificate");
+        require(certificates.isValid(serialNumber, certificateHash), "Certificate should be valid");
+    }
+
+    function test_CertificateRevokesSuccessfully() public {
+        string memory serialNumber = "abc1234";
+        string memory ipfsCID = "fake-ipfs-cid";
+        bytes32 certificateHash = keccak256("test-cert-hash");
+
+        certificates.registerCertificate(serialNumber, ipfsCID, certificateHash);
+        require(certificates.getTotalCertificates() == 1, "Should have 1 certificate");
+
+        // Verify initial state
+        _verifyCertificateData(serialNumber, ipfsCID, certificateHash, false);
+
+        // Revoke the certificate
+        certificates.revokeCertificate(serialNumber);
+
+        // Verify revoked state
+        _verifyCertificateData(serialNumber, ipfsCID, certificateHash, true);
+    }
+
+    function _verifyCertificateData(
+        string memory serialNumber,
+        string memory ipfsCID,
+        bytes32 certificateHash,
+        bool shouldBeRevoked
+    ) internal view {
+        (
+            string memory retSerial,
+            string memory retIpfs,
+            bytes32 retHash,
+            address retOwner,
+            uint256 retTimestamp,
+            bool retRevoked
+        ) = certificates.getCertificate(serialNumber);
+
+        require(keccak256(bytes(retSerial)) == keccak256(bytes(serialNumber)), "Serial number mismatch");
+        require(keccak256(bytes(retIpfs)) == keccak256(bytes(ipfsCID)), "IPFS CID mismatch");
+        require(retHash == certificateHash, "Certificate hash mismatch");
+        require(retOwner == address(this), "Owner mismatch");
+        require(retRevoked == shouldBeRevoked, shouldBeRevoked ? "Should be revoked" : "Should not be revoked");
+        require(retTimestamp > 0, "Timestamp should be set");
+    }
+
+
 }


### PR DESCRIPTION
This adds the smart contract functions required for certificate management. I added most of the testing, we could add some more if we wanted, but the `registerCertificate` method should be 100% covered.